### PR TITLE
Change purpose to address supercollider community

### DIFF
--- a/sc-coc.md
+++ b/sc-coc.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-A primary goal of all the conferences and user groups that refer to this Code of Conduct is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all.
+A primary goal of our community, our user groups and mailing lists, symposia and other events is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all.
 
 This Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 


### PR DESCRIPTION
Berlin Code of Conduct is meant for use by many different event organizers,
not specifically for user groups and mailing lists.
